### PR TITLE
delete red text on SP location page

### DIFF
--- a/locations/stevens-point-wi.html
+++ b/locations/stevens-point-wi.html
@@ -9,14 +9,6 @@ description: Dr. Jason J. Potocki is the orthopedic spine surgeon located at our
 	  <h1 class="entry-title">Stevens Point, WI</h1>
   </header>
 	<div class="entry-content">
-      <p style="color:red"><em>Please note that our Stevens Point office is temporarily divided between two nearby
-        locations:</em></p>
-        <ul style="color:red">
-          <li><em>For spine surgery appointments, patients should visit 500 Vincent Street (within the same
-              complex as Stevens Point Orthopedics, formerly Klasinski Clinic).</em></li> 
-          <li><em>For physical therapy appointments, patients should visit the adjacent building at 520 Vincent Street.</em></li>
-        </ul>
-        <p style="color:red"><em><strong>Please call our office if you have any questions regarding the location of your appointment.</strong></em></p>
       <p><a href="{{ "/team/jason-potocki/" | relative_url }}">Dr. Jason J. Potocki</a> is the
       orthopedic spine surgeon directing our Stevens Point location, which also offers X-ray, MRI,
       and physical therapy services.</p>


### PR DESCRIPTION
This text directing patients between two different Stevens Point locations is no longer necessary and has been removed.